### PR TITLE
Update to 1.3.2

### DIFF
--- a/commands/avatar.js
+++ b/commands/avatar.js
@@ -37,7 +37,7 @@ module.exports = {
           text: config.footerTxt
         },
         image: {
-          url: target.displayAvatarURL()
+          url: target.displayAvatarURL({ dynamic: true })
         }
       }]
     };

--- a/commands/invite.js
+++ b/commands/invite.js
@@ -27,7 +27,7 @@ module.exports = {
         },
         fields: [
           { name: 'Anitrox', value: 'Get the ripe off the vine Anitrox! \n [Add Anitrox to your server](https://discord.com/oauth2/authorize?client_id=576805923964715018&scope=bot&permissions=8)' },
-          { name: 'Anitrox PTB (Public Test Build)', value: 'So you want the fresh and hot builds straight from the oven? We gotchu \n [Add Anitrox PTB to your server](https://discord.com/oauth2/authorize?client_id=489125054261755925&scope=bot&permissions=66186303)' },
+          { name: 'Anitrox PTB (Public Test Build)', value: 'Anitrox PTB is going to be discontinued on November 25th, 2022. [Learn More](https://docs.google.com/document/d/1cpmJjBEo-blxvirOtDsIT-Hrq40qVseRHBY7asBT47k)' },
           { name: 'Anitrox Dev, Self hosting and more!', value: 'Self-host your own Anitrox (including dev!), Contribute, and more! The possibilites are endless. [Anitrox Source](https://github.com/IDeletedSystem64/anitrox)' },
           { name: 'Need help?', value: 'Come join the Anitrox Support Server, for support and much more!\n [Anitrox Support Server](https://discord.gg/grebRGsBZ3)' }
         ]

--- a/config-example.json
+++ b/config-example.json
@@ -1,7 +1,7 @@
 {
   "prefix": "n!",
   "release": "Stable Release",
-  "build": "1.3",
+  "build": "1.3.2",
   "footerTxt": "Anitrox, made with <3 by IDeletedSystem64 | 2018-2022",
   "sandbox": {
     "enabled": false,

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -8,7 +8,7 @@ module.exports = {
           await client.commands.get(interaction.commandName)?.parseInteraction(client, config, interaction);
         } catch (error) {
           console.error(error);
-          interaction.channel.send({
+          interaction.reply({
             embeds: [{
               title: '<:AnitroxError:809651936563429416> **Something went wrong!**',
               description: error.stack,

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -14,7 +14,7 @@ module.exports = {
         message.channel.send({
           embeds: [{
             title: `<:AnitroxWarning:997565364718276669> Attention, ${message.author.username}!`,
-            description: `Anitrox will be moving entirely to slash commands in 1.4, You will no longer be able to use commands by typing ${config.prefix}command.\n Please use slash commands in the future. [Learn more](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ)`,
+            description: `Anitrox will be moving entirely to slash commands in 1.4, You will no longer be able to use \`\` ${command} \`\` by typing ${config.prefix}${command}.\n Please use slash commands in the future. [Learn more](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ)`,
             color: 15548997,
             footer: {
               icon_url: message.author.displayAvatarURL(),


### PR DESCRIPTION
This is a hotfix release to fix several issues with 1.3 and prior versions

**Changes**
+ ``avatar`` now displays the GIF avatar on users that have a Nitro animated profile picture
+ Error messages now reply to the interaction, rather than sending as a separate message (No more looking like the bot is talking to itself!)
~ Removed PTB invite link from invite, PTB is being discontinued on Nov 25th anyway.
