### PR TITLE
Update to 1.3.3

### DIFF
--- a/commands/avatar.js
+++ b/commands/avatar.js
@@ -30,15 +30,12 @@ module.exports = {
   handle (_, config, user, target) {
     return {
       embeds: [{
-        title: `:frame_photo: ${target.username}'s Beautiful Avatar!`,
+        title: `:frame_photo: ${target.username}'s Beautiful Profile Picture!`,
+        description: `[Profile picture link (Mobile users, tap here!)](${target.displayAvatarURL({ dynamic: true })})`,
         color: 9442302,
-        footer: {
-          icon_url: user.displayAvatarURL(),
-          text: config.footerTxt
-        },
-        image: {
-          url: target.displayAvatarURL({ dynamic: true })
-        }
+        image: { url: target.displayAvatarURL({ dynamic: true }) },
+        footer: { icon_url: user.displayAvatarURL(), text: config.footerTxt }
+
       }]
     };
   }

--- a/commands/contributors.js
+++ b/commands/contributors.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   name: require('path').parse(__filename).name,
-  description: 'Attributions to open source components used by Anitrox',
+  description: 'Attributions to users who have worked on Anitrox!',
   options: [],
 
   async parseMessage (_, config, message) {
@@ -28,11 +28,11 @@ module.exports = {
         fields: [
           {
             name: 'chuu_shi',
-            value: 'Thanks to Chuu for letting me use some of his resources to host Anitrox!\n <:GitHub:778165439477841981> [Check out his code!](https://github.com/chuushi)'
+            value: 'Thanks to Chuu for letting me use some of his resources to host Anitrox!\n <:GitHub:778165439477841981> [Check out his code!](https://github.com/chuushi)\n <:discord:1057053513210937444> [Check out his Discord community!](https://port.chuu.sh/)'
           },
           {
-            name: 'OfficialTCGMatt',
-            value: "Matt has helped quite a bit with Anitrox, especially in the early days of Anitrox's development! He even has his own bot!\n <:GitHub:778165439477841981> [Check out his code!](https://github.com/OfficialTCGMatt)\n :robot: [Check out TheCodingBot!](https://github.com/TMC-Software/TheCodingBot)"
+            name: 'TheCodingGuy',
+            value: "Matt has helped quite a bit with Anitrox, especially in the early days of Anitrox's development! He even has his own bot!\n <:GitHub:778165439477841981> [Check out his code!](https://github.com/Aisuruneko)\n :robot: [Check out TheCodingBot!](https://github.com/NetroCorp/TheCodingBot)\n :globe_with_meridians: [Check out Netro Corp!](https://netrocorp.net)"
           },
           {
             name: 'Foxinatel',

--- a/commands/restart.js
+++ b/commands/restart.js
@@ -16,7 +16,7 @@ module.exports = {
     if (user.id === process.env.OWNERID) {
       const embeds = [{
         title: '<a:AnitroxWorking:997565411212144730>  Restart Bot',
-        description: 'Restarting Anitrox...',
+        description: '<a:AnitroxWorking:997565411212144730> Restarting now, Be back in a minute!',
         color: 9442302,
         footer: {
           icon_url: user.displayAvatarURL(),

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -17,8 +17,8 @@ module.exports = {
       console.log('[SYSTEM] [INFO] ' + `The bot is going down for shut down. \nShutdown requested by ${user.username}`);
       await channel.send({
         embeds: [{
-          title: '**Shut down the bot**',
-          description: '<a:AnitroxWorking:997565411212144730> **Shutting Down...**',
+          title: 'Shut down the bot',
+          description: '<a:AnitroxWorking:997565411212144730> Shutting down now, Until next time!',
           color: 9442302,
           footer: {
             icon_url: user.displayAvatarURL(),

--- a/config-example.json
+++ b/config-example.json
@@ -1,8 +1,8 @@
 {
   "prefix": "n!",
   "release": "Developer Release",
-  "build": "1.4dev",
-  "footerTxt": "Anitrox, made with <3 by IDeletedSystem64 | 2018-2022",
+  "build": "1.3.3dev",
+  "footerTxt": "Anitrox, made with <3 by IDeletedSystem64 | 2018-2023",
   "sandbox": {
     "enabled": false,
     "id": "0",

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -11,17 +11,6 @@ module.exports = {
       if (!client.commands.has(command)) return;
 
       try {
-        message.channel.send({
-          embeds: [{
-            title: `<:AnitroxWarning:997565364718276669> Attention, ${message.author.username}!`,
-            description: `Anitrox will be moving entirely to slash commands in 1.4, You will no longer be able to use \`\` ${command} \`\` by typing ${config.prefix}${command}.\n Please use slash commands in the future. [Learn more](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ)`,
-            color: 15548997,
-            footer: {
-              icon_url: message.author.displayAvatarURL(),
-              text: config.footerTxt
-            }
-          }]
-        });
         await client.commands.get(command)?.parseMessage(client, config, message, args);
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
Changes:

Update and add links to ``contributors``

Remove the prefix removal notice when commands are run with a prefix, This was decided based on a Twitter poll on what type of commands users prefer (slash or prefix), We will continue to support prefix and slash commands moving forward.

Add a link to the avatar command so mobile users can download or view profile pictures in their browser.

Update the messages for shutdown/restart